### PR TITLE
Add back to home link on /all

### DIFF
--- a/back/src/routes/all.html
+++ b/back/src/routes/all.html
@@ -8,4 +8,10 @@
   <ul>
     {news_list}
   </ul>
+
+  <p class="has-text-right is-size-4">
+    <a href="/">
+      ← Back to home
+    </a>
+  </p>
 </div>


### PR DESCRIPTION
Great job making TWIN!

I was looking at the website and was struggling for a second going back to the home page after navigating to /all (before clicking the header).

I thought it might be more intuitive to have a link mirroring `More updates ->` to get back to the home page so I added a `<- Back to home` link on /all.

Perhaps it won't make sense here with pagination?

![image](https://user-images.githubusercontent.com/76068197/188334792-d8b94f56-be5a-43bf-8735-9002057b6de6.png)
