### PR TITLE
Note project state; Warn about old url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Notice: This project now lives at https://dotfyle.com/this-week-in-neovim.
+Notice: A continuation of this project now lives at https://dotfyle.com/this-week-in-neovim.\
 See https://dotfyle.com/this-week-in-neovim/46#update-twin for a longer explanation.
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
+Notice: This project now lives at https://dotfyle.com/this-week-in-neovim.
+See https://dotfyle.com/this-week-in-neovim/46#update-twin for a longer explanation.
+
+---
+
 # This Week In Neovim
 
-This repository holds the source code of https://this-week-in-neovim.org.
+This repository holds the source code of https://this-week-in-neovim.org (this domain does not belong to this project anymore. Use at your own risk.).
 
 <!-- vim-markdown-toc GFM -->
 


### PR DESCRIPTION
The url now leads to a sketchy looking gambling (? as far as I can tell. I did not want to click around any further) site.

This PR just adds a notice to lead people to the continuation of the project and adds a small note that the URL does belong to the project anymore.


P.S.: Thanks for all the work that went into the project :)